### PR TITLE
More customization in `STLineNumberRulerView` & `STTextView`

### DIFF
--- a/Sources/STTextView/STLineNumberRulerView.swift
+++ b/Sources/STTextView/STLineNumberRulerView.swift
@@ -93,7 +93,7 @@ open class STLineNumberRulerView: NSRulerView {
             let ctLineWidth = ceil(CTLineGetTypographicBounds($0.ctLine, nil, nil, nil))
 
             return (
-                textPosition: $0.textPosition.moved(dx: ruleThickness - (ctLineWidth + rulePadding), dy: baselineOffset),
+                textPosition: $0.textPosition.moved(dx: ruleThickness - (ctLineWidth + rulePadding), dy: -baselineOffset),
                 ctLine: $0.ctLine
             )
         }

--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -123,6 +123,10 @@ open class STTextView: NSView, CALayerDelegate, NSTextInput {
         }
     }
 
+    public var selectedLineHighlightColor: NSColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.25)
+
+    public var selectionBackgroundColor: NSColor = NSColor.selectedTextBackgroundColor
+
     public var backgroundColor: NSColor? {
         didSet {
             layer?.backgroundColor = backgroundColor?.cgColor
@@ -370,7 +374,7 @@ open class STTextView: NSView, CALayerDelegate, NSTextInput {
             }
 
             context.saveGState()
-            context.setFillColor(NSColor.selectedTextBackgroundColor.withAlphaComponent(0.25).cgColor)
+            context.setFillColor(selectedLineHighlightColor.cgColor)
 
             let fillRect = CGRect(
                 origin: CGPoint(
@@ -456,7 +460,7 @@ open class STTextView: NSView, CALayerDelegate, NSTextInput {
                 if highlightFrame.size.width > 0 {
                     let highlightLayer = STCALayer(frame: highlightFrame)
                     highlightLayer.contentsScale = backingScaleFactor
-                    highlightLayer.backgroundColor = NSColor.selectedTextBackgroundColor.cgColor
+                    highlightLayer.backgroundColor = selectionBackgroundColor.cgColor
                     selectionLayer.addSublayer(highlightLayer)
                 } else {
                     updateInsertionPointStateAndRestartTimer()


### PR DESCRIPTION
Added some public properties which allow customization of certain UI elements. The default values are left unchanged.

## `STLineNumberRulerView`

- added `separatorColor` property: 
  *customize the color of the ruler view separator* 
- added `baselineOffset` property: 
  *customize the bottom baseline offset of the line number*

## `STTextView`

- added `selectedLineHighlightColor` property: 
  *customize the selected line highlight color in the text view*
- added `selectionBackgroundColor` property: 
  *customize the text background color of selected text*