### PR TITLE
Added property `insertionPointWidth`

### DIFF
--- a/Sources/STTextView/STTextView+InsertionPoint.swift
+++ b/Sources/STTextView/STTextView+InsertionPoint.swift
@@ -33,6 +33,7 @@ extension STTextView {
 
                     let insertionLayer = STInsertionPointLayer(frame: selectionFrame)
                     insertionLayer.insertionPointColor = insertionPointColor
+                    insertionLayer.insertionPointWidth = insertionPointWidth
                     insertionLayer.updateGeometry()
 
                     if isFirstResponder {

--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -41,6 +41,9 @@ open class STTextView: NSView, CALayerDelegate, NSTextInput {
     /// The color of the insertion point.
     open var insertionPointColor: NSColor
 
+    /// The width of the insertion point.
+    open var insertionPointWidth: CGFloat = 1.0
+
     /// The font of the text view.
     public var font: NSFont? {
         get {


### PR DESCRIPTION
Added `insertionPointWidth` to `STTextView` to make it possible to change the width of the insertion point.

Test result with a width of 10pt:

```swift
var textView = STTextView()
textView.insertionPointWidth = 10.0
```

<img alt="Screen Shot 2022-05-28 at 18 05 11" src="https://user-images.githubusercontent.com/9460130/170834066-affaddd3-a1db-4cf1-ab18-7ce34e168901.png">

