### PR TITLE
Function to get current caret position

### DIFF
--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -399,7 +399,7 @@ open class STTextView: NSView, CALayerDelegate, NSTextInput {
         guard let carretPosStr = textLayoutManager.insertionPointLocation?.description as? String,
               let carretPos = Int.init(carretPosStr)
         else {
-            print("Failed to get position")
+            Log.info("Failed to get position")
             return
         }
 
@@ -412,12 +412,12 @@ open class STTextView: NSView, CALayerDelegate, NSTextInput {
         }
 
         /// Split newlines
-        let splitValue = txtStr.split(separator: "\n")
+        let splitValue = txtStr.components(separatedBy: "\n")
 
         // Check on what row we are
         row = splitValue.count
 
-        if splitValue.count > 0 {
+        if !splitValue.isEmpty {
             // We are > row 0, so count with the correct row
             // splitValue[row - 1], is the row contents.
             // .utf8.count gives us the (current) length of the string
@@ -425,15 +425,6 @@ open class STTextView: NSView, CALayerDelegate, NSTextInput {
         } else {
             // .count gives us the (current) length of the string
             col = txtStr.count
-        }
-
-        // This seems weird, but if we split \n into an empty line,
-        // it doesn't count, so we check if the character in range
-        // before the caret has a \n, in that case we are on a new
-        // row, without any contents. (row + 1, col = 0)
-        if txtStr.hasSuffix("\n") {
-            row += 1
-            col = 0
         }
 
         // Update value to delegate

--- a/Sources/STTextView/STTextViewDelegate.swift
+++ b/Sources/STTextView/STTextViewDelegate.swift
@@ -25,6 +25,9 @@ public protocol STTextViewDelegate: AnyObject {
 
     func textView(_ textView: STTextView, insertCompletionItem item: Any)
 
+    /// Sent when the caret is moved
+    func textView(_ textView: STTextView, didMoveCaretTo row: Int, column: Int)
+
     // Due to Swift 5.6 generics limitation it can't return STCompletionViewControllerProtocol
     func textViewCompletionViewController(_ textView: STTextView) -> STAnyCompletionViewController?
 }
@@ -67,6 +70,10 @@ public extension STTextViewDelegate {
         
     }
 
+    func textView(_ textView: STTextView, didMoveCaretTo row: Int, column: Int) {
+
+    }
+    
     func textViewCompletionViewController(_ textView: STTextView) -> STAnyCompletionViewController? {
         nil
     }


### PR DESCRIPTION
Hi,

This commit adds a delegate function what triggers if the caret has moved.

```swift
func textView(_ textView: STTextView, didMoveCaretTo row: Int, column: Int) { }
```