### PR TITLE
Fix crash when get attribute from empty string

### DIFF
--- a/Sources/STTextView/STLineNumberRulerView.swift
+++ b/Sources/STTextView/STLineNumberRulerView.swift
@@ -80,6 +80,7 @@ open class STLineNumberRulerView: NSRulerView {
         textView?.textLayoutManager.enumerateTextLayoutFragments(from: textView?.textLayoutManager.documentRange.location, options: [.ensuresLayout, .ensuresExtraLineFragment]) { textLayoutFragment in
 
             for textLineFragment in textLayoutFragment.textLineFragments where (textLineFragment.isExtraLineFragment || textLayoutFragment.textLineFragments.first == textLineFragment) {
+                if textLineFragment.attributedString.length == 0 { break }
                 var baselineOffset: CGFloat = 0
                 if let paragraphStyle = textLineFragment.attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle, !paragraphStyle.lineHeightMultiple.isAlmostZero() {
                     baselineOffset = -(textLineFragment.typographicBounds.height * (paragraphStyle.lineHeightMultiple - 1.0) / 2)

--- a/Sources/STTextView/STTextLayoutManager.swift
+++ b/Sources/STTextView/STTextLayoutManager.swift
@@ -41,6 +41,7 @@ private final class STTextLayoutFragment: NSTextLayoutFragment {
         // Center vertically after applying lineHeightMultiple value
         // super.draw(at: point.moved(dx: 0, dy: offset), in: context)
         for lineFragment in textLineFragments {
+            if lineFragment.attributedString.length == 0 { break }
             if let paragraphStyle = lineFragment.attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle, !paragraphStyle.lineHeightMultiple.isAlmostZero() {
                 let offset = -(lineFragment.typographicBounds.height * (paragraphStyle.lineHeightMultiple - 1.0) / 2)
                 lineFragment.draw(at: point.moved(dx: lineFragment.typographicBounds.origin.x, dy: lineFragment.typographicBounds.origin.y + offset), in: context)


### PR DESCRIPTION
call on `textLineFragment.attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil)` is crashing when open empty file/string