### PR TITLE
Adding option to extend the line highlighting to the ruler

### DIFF
--- a/STTextViewDemo/ViewController.swift
+++ b/STTextViewDemo/ViewController.swift
@@ -28,7 +28,9 @@ final class ViewController: NSViewController {
         // Line numbers
         let rulerView = STLineNumberRulerView(textView: textView, scrollView: scrollView)
         // Configure the ruler view
-        rulerView.highlightRulerForegroundColor = NSColor.white
+        rulerView.drawHighlightedRuler = true
+        rulerView.highlightLineNumberColor = .white
+
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true
 

--- a/STTextViewDemo/ViewController.swift
+++ b/STTextViewDemo/ViewController.swift
@@ -26,7 +26,10 @@ final class ViewController: NSViewController {
         textView.string = try! String(contentsOf: Bundle.main.url(forResource: "content", withExtension: "txt")!)
 
         // Line numbers
-        scrollView.verticalRulerView = STLineNumberRulerView(textView: textView, scrollView: scrollView)
+        let rulerView = STLineNumberRulerView(textView: textView, scrollView: scrollView)
+        // Configure the ruler view
+        rulerView.highlightRulerForegroundColor = NSColor.white
+        scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true
 
         // textView.addAttributes([.font: NSFont.systemFont(ofSize: 50)], range: NSRange(location: 0, length: 1))

--- a/STTextViewDemo/ViewController.swift
+++ b/STTextViewDemo/ViewController.swift
@@ -29,7 +29,7 @@ final class ViewController: NSViewController {
         let rulerView = STLineNumberRulerView(textView: textView, scrollView: scrollView)
         // Configure the ruler view
         rulerView.drawHighlightedRuler = true
-        rulerView.highlightLineNumberColor = .white
+        rulerView.highlightLineNumberColor = .textColor
 
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true

--- a/Sources/STTextView/STLineNumberRulerView.swift
+++ b/Sources/STTextView/STLineNumberRulerView.swift
@@ -55,8 +55,6 @@ open class STLineNumberRulerView: NSRulerView {
 
     private var lines: [(textPosition: CGPoint, ctLine: CTLine)] = []
     
-    typealias lineAttributes = [NSAttributedString.Key: Any]
-
     public required init(textView: STTextView, scrollView: NSScrollView) {
         font = textView.font ?? NSFont(descriptor: NSFont.monospacedDigitSystemFont(ofSize: NSFont.labelFontSize, weight: .regular).fontDescriptor.withSymbolicTraits(.condensed), size: NSFont.labelFontSize) ?? NSFont.monospacedSystemFont(ofSize: NSFont.labelFontSize, weight: .regular)
 
@@ -85,12 +83,12 @@ open class STLineNumberRulerView: NSRulerView {
     }
 
     private func invalidateLineNumbers() {
-        let attributes: lineAttributes = [
+        let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: textColor
         ]
         
-        let highlightAttributes: lineAttributes = [
+        let highlightAttributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: highlightLineNumberColor.cgColor
         ]
@@ -177,7 +175,8 @@ open class STLineNumberRulerView: NSRulerView {
     }
     
     // Return text attributes depending on whether the ruleline is highlighted or not.
-    private func determineLineNumberAttribute(_ yPosition: CGFloat, _ attributes: lineAttributes, highlightWith highlightAttributes: lineAttributes) -> lineAttributes {
+    private func determineLineNumberAttribute(_ yPosition: CGFloat, _ attributes: [NSAttributedString.Key: Any],
+                                              highlightWith highlightAttributes: [NSAttributedString.Key: Any]) -> [NSAttributedString.Key: Any] {
         guard let textLayoutManager = textView?.textLayoutManager,
               let caretLocation = textLayoutManager.insertionPointLocation,
               drawHighlightedRuler == true

--- a/Sources/STTextView/STLineNumberRulerView.swift
+++ b/Sources/STTextView/STLineNumberRulerView.swift
@@ -221,7 +221,7 @@ open class STLineNumberRulerView: NSRulerView {
             origin: originPoint,
             size: CGSize(
                 width: frame.width,
-                height: textView!.typingLineHeight
+                height: selectionFrame.height
                 )
             )
                 
@@ -247,6 +247,11 @@ open class STLineNumberRulerView: NSRulerView {
             context.addLines(between: [CGPoint(x: ruleThickness, y: 0), CGPoint(x: ruleThickness, y: frame.maxY) ])
             context.strokePath()
         }
+        
+        // Needs to run before adding the lines, since it will not be set as the background otherwise
+        if drawHighlightedRuler {
+            drawHighlightedRuler(context, relativePoint, in: dirtyRect)
+        }
 
         context.textMatrix = CGAffineTransform(scaleX: 1, y: isFlipped ? -1 : 1)
 
@@ -257,9 +262,6 @@ open class STLineNumberRulerView: NSRulerView {
 
         context.restoreGState()
 
-        if drawHighlightedRuler {
-            drawHighlightedRuler(context, relativePoint, in: dirtyRect)
-        }
         drawHashMarksAndLabels(in: dirtyRect)
 
         if let markers = markers, !markers.isEmpty {

--- a/Sources/STTextView/STLineNumberRulerView.swift
+++ b/Sources/STTextView/STLineNumberRulerView.swift
@@ -221,7 +221,7 @@ open class STLineNumberRulerView: NSRulerView {
             origin: originPoint,
             size: CGSize(
                 width: frame.width,
-                height: selectionFrame.height
+                height: textView!.typingLineHeight
                 )
             )
                 

--- a/Sources/STTextView/STLineNumberRulerView.swift
+++ b/Sources/STTextView/STLineNumberRulerView.swift
@@ -33,13 +33,13 @@ open class STLineNumberRulerView: NSRulerView {
     open var backgroundColor: NSColor = NSColor.controlBackgroundColor
     
     @Invalidating(.display)
-    open var drawHighlightedRuler: Bool = true
+    open var drawHighlightedRuler: Bool = false
     
     @Invalidating(.display)
     open var highlightRulerBackgroundColor: NSColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.25)
     
     @Invalidating(.display)
-    open var highlightRulerForegroundColor: NSColor = .textColor
+    open var highlightLineNumberColor: NSColor = .textColor
 
     /// The color of the separator.
     ///
@@ -92,7 +92,7 @@ open class STLineNumberRulerView: NSRulerView {
         
         let highlightAttributes: lineAttributes = [
             .font: font,
-            .foregroundColor: highlightRulerForegroundColor.cgColor
+            .foregroundColor: highlightLineNumberColor.cgColor
         ]
         lines.removeAll(keepingCapacity: true)
 
@@ -179,7 +179,8 @@ open class STLineNumberRulerView: NSRulerView {
     // Return text attributes depending on whether the rule line is highlighted or not.
     private func highlightAttribute(_ yPosition: CGFloat, _ attributes: lineAttributes, highlightWith highlightAttributes: lineAttributes) -> lineAttributes {
         guard let textLayoutManager = textView?.textLayoutManager,
-              let caretLocation = textLayoutManager.insertionPointLocation
+              let caretLocation = textLayoutManager.insertionPointLocation,
+              drawHighlightedRuler == true
         else {
             return attributes
         }
@@ -221,7 +222,7 @@ open class STLineNumberRulerView: NSRulerView {
             origin: originPoint,
             size: CGSize(
                 width: frame.width,
-                height: selectionFrame.height
+                height: textView?.typingLineHeight ?? selectionFrame.height
                 )
             )
                 


### PR DESCRIPTION
### Code:

I effectively added two new functions to accomplish the highlighting:

1. `drawHighlightedRuler()`: Inserts a rectangle in the background of the ruler to make it seem like the highlight goes across the whole view.
2. `determineLineNumberAttributes()`: Determines whether the current ctLine is highlighted and returns the right textAttribute accordingly (highlighted or not highlighted). 


### Configuration:
The ruler highlighting is disabled by default. To enable it, one has to set the flag `.drawHighlightedRuler = true`.
The ruler can then be configured like so:

```swift
let rulerView = STLineNumberRulerView(textView: textView, scrollView: scrollView)
// Configure the ruler view
rulerView.drawHighlightedRuler = true
rulerView.highlightRulerBackgroundColor = .gray
rulerView.highlightLineNumberColor = .textColor
```

### Example:
<img width="571" alt="image" src="https://user-images.githubusercontent.com/82230675/210236777-3f680084-9d07-468d-b1bd-743f69a959ea.png">

Since I am new to swift, the formatting of the new code might be a bit off.