### PR TITLE
Splitting the ruler padding into left and right padding

### DIFF
--- a/STTextViewDemo/ViewController.swift
+++ b/STTextViewDemo/ViewController.swift
@@ -30,6 +30,7 @@ final class ViewController: NSViewController {
         // Configure the ruler view
         rulerView.drawHighlightedRuler = true
         rulerView.highlightLineNumberColor = .textColor
+        rulerView.rulerInsets = STRulerInsets(leading: 6.0, trailing: 6.0)
 
         scrollView.verticalRulerView = rulerView
         scrollView.rulersVisible = true

--- a/Sources/STTextView/STLineNumberRulerView.swift
+++ b/Sources/STTextView/STLineNumberRulerView.swift
@@ -16,13 +16,10 @@ open class STLineNumberRulerView: NSRulerView {
     /// text view font changes.
     open var font: NSFont
 
-    /// The horizontal padding of the ruler view.
+    /// The insets of the ruler view.
     @Invalidating(.display)
-    open var leftRulePadding: CGFloat = 6
+    open var rulerInsets: STRulerInsets = STRulerInsets(leading: 6.0, trailing: 6.0)
     
-    @Invalidating(.display)
-    open var rightRulePadding: CGFloat = 6
-
     /// The text color of the line numbers.
     @Invalidating(.display)
     open var textColor: NSColor = .secondaryLabelColor
@@ -161,8 +158,8 @@ open class STLineNumberRulerView: NSRulerView {
         // Adjust ruleThickness based on last (longest) value
         if let lastLine = lines.last {
             let ctLineWidth = CTLineGetTypographicBounds(lastLine.ctLine, nil, nil, nil)
-            if ruleThickness < (ctLineWidth + (leftRulePadding + rightRulePadding)) {
-                self.ruleThickness = max(self.ruleThickness, ctLineWidth + (leftRulePadding + rightRulePadding))
+            if ruleThickness < (ctLineWidth + (rulerInsets.leading + rulerInsets.trailing)) {
+                self.ruleThickness = max(self.ruleThickness, ctLineWidth + (rulerInsets.leading + rulerInsets.trailing))
             }
         }
 
@@ -171,7 +168,7 @@ open class STLineNumberRulerView: NSRulerView {
             let ctLineWidth = ceil(CTLineGetTypographicBounds($0.ctLine, nil, nil, nil))
 
             return (
-                textPosition: $0.textPosition.moved(dx: ruleThickness - (ctLineWidth + rightRulePadding), dy: -baselineOffset),
+                textPosition: $0.textPosition.moved(dx: ruleThickness - (ctLineWidth + rulerInsets.trailing), dy: -baselineOffset),
                 ctLine: $0.ctLine
             )
         }

--- a/Sources/STTextView/STLineNumberRulerView.swift
+++ b/Sources/STTextView/STLineNumberRulerView.swift
@@ -18,7 +18,10 @@ open class STLineNumberRulerView: NSRulerView {
 
     /// The horizontal padding of the ruler view.
     @Invalidating(.display)
-    open var rulePadding: CGFloat = 6
+    open var leftRulePadding: CGFloat = 6
+    
+    @Invalidating(.display)
+    open var rightRulePadding: CGFloat = 6
 
     /// The text color of the line numbers.
     @Invalidating(.display)
@@ -158,8 +161,8 @@ open class STLineNumberRulerView: NSRulerView {
         // Adjust ruleThickness based on last (longest) value
         if let lastLine = lines.last {
             let ctLineWidth = CTLineGetTypographicBounds(lastLine.ctLine, nil, nil, nil)
-            if ruleThickness < (ctLineWidth + (rulePadding * 2)) {
-                self.ruleThickness = max(self.ruleThickness, ctLineWidth + (self.rulePadding * 2))
+            if ruleThickness < (ctLineWidth + (leftRulePadding + rightRulePadding)) {
+                self.ruleThickness = max(self.ruleThickness, ctLineWidth + (leftRulePadding + rightRulePadding))
             }
         }
 
@@ -168,7 +171,7 @@ open class STLineNumberRulerView: NSRulerView {
             let ctLineWidth = ceil(CTLineGetTypographicBounds($0.ctLine, nil, nil, nil))
 
             return (
-                textPosition: $0.textPosition.moved(dx: ruleThickness - (ctLineWidth + rulePadding), dy: -baselineOffset),
+                textPosition: $0.textPosition.moved(dx: ruleThickness - (ctLineWidth + rightRulePadding), dy: -baselineOffset),
                 ctLine: $0.ctLine
             )
         }

--- a/Sources/STTextView/Utility/STLineNumberTypes.swift
+++ b/Sources/STTextView/Utility/STLineNumberTypes.swift
@@ -1,10 +1,11 @@
 //  Created by Elias Wahl on 14.01.23.
+import Foundation
 
 public struct STRulerInsets: Equatable {
-    public let leading: Double
-    public let trailing: Double
+    public let leading: CGFloat
+    public let trailing: CGFloat
     
-    public init(leading: Double, trailing: Double) {
+    public init(leading: CGFloat, trailing: CGFloat) {
         self.leading = leading
         self.trailing = trailing
     }

--- a/Sources/STTextView/Utility/STLineNumberTypes.swift
+++ b/Sources/STTextView/Utility/STLineNumberTypes.swift
@@ -1,0 +1,12 @@
+//  Created by Elias Wahl on 14.01.23.
+
+public struct STRulerInsets: Equatable {
+    public let leading: Double
+    public let trailing: Double
+    
+    public init(leading: Double, trailing: Double) {
+        self.leading = leading
+        self.trailing = trailing
+    }
+    
+}


### PR DESCRIPTION
I was thinking, that it should be possible to split the ruler padding into left and right padding:

```swift
rulerView.leftRulePadding = 30
rulerView.rightRulePadding = 6
```
Alternatively, we could add a horizontal text offset property instead. That would have the same effect.
However, I feel like having two separate paddings is easier to understand.


Just an example:
<img width="571" alt="image" src="https://user-images.githubusercontent.com/82230675/210678468-945f9f2e-135b-40c7-9480-affec865c079.png">

