### PR TITLE
Add shouldChangeText check to Delete

### DIFF
--- a/Sources/STTextView/STTextView+Delete.swift
+++ b/Sources/STTextView/STTextView+Delete.swift
@@ -83,7 +83,7 @@ extension STTextView {
             }
         }
 
-        if textRanges.isEmpty {
+        if textRanges.isEmpty || !shouldChangeText(in: textRanges, replacementString: nil) {
             return nil
         }
 


### PR DESCRIPTION
Adds a call to `shouldChangeText` in Delete to ensure delegates are informed of deletes.