### PR TITLE
make textLineFragment public

### DIFF
--- a/Sources/STTextView/Extensions/NSTextLayoutManager+Helpers.swift
+++ b/Sources/STTextView/Extensions/NSTextLayoutManager+Helpers.swift
@@ -84,11 +84,11 @@ extension NSTextLayoutManager {
         return result
     }
 
-    func textLineFragment(at location: NSTextLocation) -> NSTextLineFragment? {
+    public func textLineFragment(at location: NSTextLocation) -> NSTextLineFragment? {
         textLayoutFragment(for: location)?.textLineFragment(at: location)
     }
 
-    func textLineFragment(at point: CGPoint) -> NSTextLineFragment? {
+    public func textLineFragment(at point: CGPoint) -> NSTextLineFragment? {
         textLayoutFragment(for: point)?.textLineFragment(at: point)
     }
 


### PR DESCRIPTION
The extension of NSTextLayoutManager has a method textLineFragment, which used to be public, and then was changed to internal. I think it should be fine to keep it public. Also, making it internal breaks CodeEditTextView.