### PR TITLE
Add a minimal set of @MainActor annotations

### DIFF
--- a/Sources/STTextView/Plugin/STPlugin.swift
+++ b/Sources/STTextView/Plugin/STPlugin.swift
@@ -12,6 +12,7 @@ public protocol STPlugin {
     func setUp(context: Context)
 
     /// Creates an object to coordinate with the text view.
+    @MainActor
     func makeCoordinator(context: CoordinatorContext) -> Self.Coordinator
 
     /// Provides an opportunity to perform cleanup after plugin is about to remove.

--- a/Sources/STTextView/Plugin/STPluginEvents.swift
+++ b/Sources/STTextView/Plugin/STPluginEvents.swift
@@ -6,9 +6,11 @@ import AppKit
 
 public class STPluginEvents {
 
+    public typealias ShouldChangeTextHandler = @MainActor (_ affectedCharRange: NSTextRange, _ replacementString: String?) -> Bool
+
     var willChangeTextHandler: ((_ affectedRange: NSTextRange) -> Void)?
     var didChangeTextHandler: ((_ affectedRange: NSTextRange, _ replacementString: String?) -> Void)?
-    var shouldChangeTextHandler: ((_ affectedCharRange: NSTextRange, _ replacementString: String?) -> Bool)?
+    var shouldChangeTextHandler: ShouldChangeTextHandler?
     var onContextMenuHandler: ((_ location: NSTextLocation, _ contentManager: NSTextContentManager) -> NSMenu)?
     var didLayoutViewportHandler: ((_ visibleRange: NSTextRange?) -> Void)?
 
@@ -24,9 +26,8 @@ public class STPluginEvents {
         return self
     }
 
-
     @discardableResult
-    public func shouldChangeText(_ handler: @escaping (_ affectedCharRange: NSTextRange, _ replacementString: String?) -> Bool) -> Self {
+    public func shouldChangeText(_ handler: @escaping ShouldChangeTextHandler) -> Self {
         shouldChangeTextHandler = handler
         return self
     }

--- a/Sources/STTextView/Plugin/STPluginEvents.swift
+++ b/Sources/STTextView/Plugin/STPluginEvents.swift
@@ -6,11 +6,9 @@ import AppKit
 
 public class STPluginEvents {
 
-    public typealias ShouldChangeTextHandler = @MainActor (_ affectedCharRange: NSTextRange, _ replacementString: String?) -> Bool
-
     var willChangeTextHandler: ((_ affectedRange: NSTextRange) -> Void)?
     var didChangeTextHandler: ((_ affectedRange: NSTextRange, _ replacementString: String?) -> Void)?
-    var shouldChangeTextHandler: ShouldChangeTextHandler?
+    var shouldChangeTextHandler: (@MainActor (_ affectedCharRange: NSTextRange, _ replacementString: String?) -> Bool)?
     var onContextMenuHandler: ((_ location: NSTextLocation, _ contentManager: NSTextContentManager) -> NSMenu)?
     var didLayoutViewportHandler: ((_ visibleRange: NSTextRange?) -> Void)?
 
@@ -27,7 +25,7 @@ public class STPluginEvents {
     }
 
     @discardableResult
-    public func shouldChangeText(_ handler: @escaping ShouldChangeTextHandler) -> Self {
+    public func shouldChangeText(_ handler: @escaping @MainActor (_ affectedCharRange: NSTextRange, _ replacementString: String?) -> Bool) -> Self {
         shouldChangeTextHandler = handler
         return self
     }

--- a/Sources/STTextView/STTextViewDelegate.swift
+++ b/Sources/STTextView/STTextViewDelegate.swift
@@ -27,6 +27,7 @@ public protocol STTextViewDelegate: AnyObject {
     func textViewDidChangeSelection(_ notification: Notification)
 
     /// Sent when a text view needs to determine if text in a specified range should be changed.
+    @MainActor
     func textView(_ textView: STTextView, shouldChangeTextIn affectedCharRange: NSTextRange, replacementString: String?) -> Bool
 
     /// Sent when a text view will change text.


### PR DESCRIPTION
I've been attempting to put together a [plugin](https://github.com/ChimeHQ/STTextView-Plugin-TextFormation) for TextFormation. It turned out to be quite difficult, but largely because I do not understand TextKit 2 at all yet.

I ran into one problem related to a lack of `@MainActor` annotations. These are potentially disruptive changes, so I made the least amount I could. And I tried to verify that these actually are called from a MainActor context exclusively.