### PR TITLE
Fix a crash in deinit.

### DIFF
--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -608,7 +608,8 @@ open class STTextView: NSView, NSTextInput, NSTextContent {
     }
 
     deinit {
-        Task { @MainActor in
+        guard !plugins.isEmpty else { return }
+        Task { @MainActor [plugins] in
             plugins.forEach { plugin, _ in
                 plugin.tearDown()
             }


### PR DESCRIPTION
There's a crash in the deinit of `STTextView`. The tear down of plugins runs asynchronously. Because of that, it can access the `plugins` property after the class is gone, resulting in a `EXC_BAD_ACCESS`.

**How to reproduce**: In the SwiftUI example app, replace the `Window` with a `WindowGroup`. Then run the app and close the window.
https://github.com/krzyzanowskim/STTextView/blob/main/TextEdit.SwiftUI/TextEditUIApp.swift#L9