### PR TITLE
Fix `HighlightView` `backgroundColor`

### DIFF
--- a/Sources/STTextView/HighlightView.swift
+++ b/Sources/STTextView/HighlightView.swift
@@ -11,4 +11,20 @@ final class HighlightView: NSView {
         false
 #endif
     }
+    
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        effectiveAppearance.performAsCurrentDrawingAppearance { [weak self] in
+            self?.layer?.backgroundColor = NSColor.selectedTextBackgroundColor.cgColor
+        }
+    }
 }

--- a/Sources/STTextView/STTextView+InsertionPoint.swift
+++ b/Sources/STTextView/STTextView+InsertionPoint.swift
@@ -16,9 +16,18 @@ extension STTextView {
             }
 
             let textSelectionFrames = insertionPointsRanges.compactMap { textRange -> CGRect? in
-                guard let selectionFrame = textLayoutManager.textSegmentFrame(in: textRange, type: .selection)?.intersection(self.frame) else {
+
+                guard var textSegmentFrame = textLayoutManager.textSegmentFrame(in: textRange, type: .selection, options: .rangeNotRequired) else {
                     return nil
                 }
+
+                if textSegmentFrame.size.width < 0 {
+                    // New issue on macOS 14 (Sonoma): textSegmentFrame.size.width can be < 0 on the edge of viewportBounds (guess)
+                    //                        resulting in unexpected selection frame
+                    textSegmentFrame.size.width = 0
+                }
+
+                let selectionFrame = textSegmentFrame.intersection(frame)
 
                 // because `textLayoutManager.enumerateTextLayoutFragments(from: nil, options: [.ensuresExtraLineFragment, .ensuresLayout, .estimatesSize])`
                 // returns unexpected value for extra line fragment height (return 14) that is not correct in the context,

--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -985,7 +985,15 @@ open class STTextView: NSView, NSTextInput, NSTextContent {
             // NOTE: enumerateTextSegments is very slow https://github.com/krzyzanowskim/STTextView/discussions/25#discussioncomment-6464398
             //       Clamp enumerated range to viewport range
             textLayoutManager.enumerateTextSegments(in: textRange, type: .selection, options: .rangeNotRequired) {(_, textSegmentFrame, _, _) in
-                let highlightFrame = textSegmentFrame.intersection(bounds).pixelAligned
+
+                var textSegmentFrame = textSegmentFrame
+                if textSegmentFrame.size.width < 0 {
+                    // New issue on macOS 14 (Sonoma): textSegmentFrame.size.width can be < 0 on the edge of viewportBounds (guess)
+                    //                        resulting in unexpected selection frame
+                    textSegmentFrame.size.width = 0
+                }
+
+                let highlightFrame = textSegmentFrame.intersection(frame).pixelAligned
                 guard !highlightFrame.isNull else {
                     return true
                 }

--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -1001,7 +1001,13 @@ open class STTextView: NSView, NSTextInput, NSTextContent {
                 if !highlightFrame.size.width.isZero {
                     let highlightView = HighlightView(frame: highlightFrame)
                     highlightView.wantsLayer = true
-                    highlightView.layer?.backgroundColor = selectionBackgroundColor.cgColor
+                    
+                    let appearanceName = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
+                    let appearance = NSAppearance(named: appearanceName ?? .aqua)
+                    appearance?.performAsCurrentDrawingAppearance {
+                        highlightView.layer?.backgroundColor = selectionBackgroundColor.cgColor
+                    }
+                    
                     selectionView.addSubview(highlightView)
 
                     // Remove insertion point when selection

--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -1000,7 +1000,6 @@ open class STTextView: NSView, NSTextInput, NSTextContent {
 
                 if !highlightFrame.size.width.isZero {
                     let highlightView = HighlightView(frame: highlightFrame)
-                    
                     selectionView.addSubview(highlightView)
 
                     // Remove insertion point when selection

--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -1000,13 +1000,6 @@ open class STTextView: NSView, NSTextInput, NSTextContent {
 
                 if !highlightFrame.size.width.isZero {
                     let highlightView = HighlightView(frame: highlightFrame)
-                    highlightView.wantsLayer = true
-                    
-                    let appearanceName = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
-                    let appearance = NSAppearance(named: appearanceName ?? .aqua)
-                    appearance?.performAsCurrentDrawingAppearance {
-                        highlightView.layer?.backgroundColor = selectionBackgroundColor.cgColor
-                    }
                     
                     selectionView.addSubview(highlightView)
 


### PR DESCRIPTION
When overriding `STTextView` appearance, `HighlightView` `backgroundColor` doesn't respect current `NSAppearance`.

https://github.com/krzyzanowskim/STTextView/assets/27621026/d3eefd41-211e-4aaf-8199-e512523c57b9

