### PR TITLE
Set up plugins when they are added after the view has been added to a window.

### DIFF
--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -35,6 +35,9 @@ import AVFoundation
     /// Installed plugins. events value is available after plugin is setup
     internal var plugins: [(plugin: any STPlugin, events: STPluginEvents?)] = []
 
+    /// Whether or not the text view is fully set up and it can setup its plugins.
+    private var isSetUp = false
+
     /// A Boolean value that controls whether the text view allows the user to edit text.
     @Invalidating(.insertionPoint, .cursorRects)
     @objc dynamic open var isEditable: Bool = true {
@@ -668,11 +671,13 @@ import AVFoundation
             textFinder.client = textFinderClient
             textFinder.findBarContainer = enclosingScrollView
 
-            for (offset, (plugin, _)) in plugins.enumerated() {
-                let events = setUp(plugin: plugin)
-
-                // set events handler
-                plugins[offset] = (plugin, events)
+            if !isSetUp {
+                for (offset, (plugin, _)) in plugins.enumerated() {
+                    let events = setUp(plugin: plugin)
+                    // set events handler
+                    plugins[offset] = (plugin, events)
+                }
+                isSetUp = true
             }
         }
 
@@ -1303,11 +1308,8 @@ import AVFoundation
     }
 
     open func addPlugin(_ plugin: any STPlugin) {
-        if window != nil {
-            plugins.append((plugin, setUp(plugin: plugin)))
-        } else {
-            plugins.append((plugin, nil))
-        }
+        let events = isSetUp ? setUp(plugin: plugin) : nil
+        plugins.append((plugin, events))
     }
 
     private func setUp(plugin: some STPlugin) -> STPluginEvents {

--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -668,19 +668,6 @@ import AVFoundation
             textFinder.client = textFinderClient
             textFinder.findBarContainer = enclosingScrollView
 
-            // unwrap any STPluginProtocol
-            func setUp(plugin: some STPlugin) -> STPluginEvents {
-                let events = STPluginEvents()
-                plugin.setUp(
-                    context: STPluginContext(
-                        coordinator: plugin.makeCoordinator(context: .init(textView: self)),
-                        textView: self,
-                        events: events
-                    )
-                )
-                return events
-            }
-
             for (offset, (plugin, _)) in plugins.enumerated() {
                 let events = setUp(plugin: plugin)
 
@@ -1316,7 +1303,23 @@ import AVFoundation
     }
 
     open func addPlugin(_ plugin: any STPlugin) {
-        plugins.append((plugin, nil))
+        if window != nil {
+            plugins.append((plugin, setUp(plugin: plugin)))
+        } else {
+            plugins.append((plugin, nil))
+        }
+    }
+
+    private func setUp(plugin: some STPlugin) -> STPluginEvents {
+        let events = STPluginEvents()
+        plugin.setUp(
+            context: STPluginContext(
+                coordinator: plugin.makeCoordinator(context: .init(textView: self)),
+                textView: self,
+                events: events
+            )
+        )
+        return events
     }
 }
 


### PR DESCRIPTION
Currently, plugins only work if they were added before the text view has moved to a window. If they are added later, they are never set up, therefore they never receive events.

This pull request changes the behavior, so plugins are always set up, even if the text view has been added to a window already.

If it's a design decision to allow adding plugins only before the text view moves to a window, then one alternative to this PR could be an assertion / warning if the `addPlugin(_ plugin: any STPlugin)` method is called later.