### PR TITLE
Make selection navigation behave like other text editors.

### DIFF
--- a/Sources/STTextView/STTextView+Select.swift
+++ b/Sources/STTextView/STTextView+Select.swift
@@ -104,7 +104,8 @@ extension STTextView {
         setTextSelections(
             direction: .left,
             destination: .character,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -112,7 +113,8 @@ extension STTextView {
         setTextSelections(
             direction: .left,
             destination: .character,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -120,7 +122,8 @@ extension STTextView {
         setTextSelections(
             direction: .right,
             destination: .character,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -128,7 +131,8 @@ extension STTextView {
         setTextSelections(
             direction: .right,
             destination: .character,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -136,7 +140,8 @@ extension STTextView {
         setTextSelections(
             direction: .up,
             destination: .character,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -144,7 +149,8 @@ extension STTextView {
         setTextSelections(
             direction: .up,
             destination: .character,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -152,7 +158,8 @@ extension STTextView {
         setTextSelections(
             direction: .down,
             destination: .character,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -160,7 +167,8 @@ extension STTextView {
         setTextSelections(
             direction: .down,
             destination: .character,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -168,7 +176,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .character,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -176,7 +185,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .character,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -184,7 +194,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .character,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -192,7 +203,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .character,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -200,7 +212,8 @@ extension STTextView {
         setTextSelections(
             direction: .left,
             destination: .word,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -208,7 +221,8 @@ extension STTextView {
         setTextSelections(
             direction: .left,
             destination: .word,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -216,7 +230,8 @@ extension STTextView {
         setTextSelections(
             direction: .right,
             destination: .word,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -224,7 +239,8 @@ extension STTextView {
         setTextSelections(
             direction: .right,
             destination: .word,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -232,7 +248,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .word,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -240,7 +257,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .word,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -248,7 +266,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .word,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -256,7 +275,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .word,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -264,7 +284,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .line,
-            extending: false
+            extending: false,
+            confined: true
         )
     }
 
@@ -272,7 +293,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .line,
-            extending: true
+            extending: true,
+            confined: true
         )
     }
 
@@ -280,7 +302,8 @@ extension STTextView {
         setTextSelections(
             direction: .left,
             destination: .line,
-            extending: false
+            extending: false,
+            confined: true
         )
     }
 
@@ -288,7 +311,8 @@ extension STTextView {
         setTextSelections(
             direction: .left,
             destination: .line,
-            extending: true
+            extending: true,
+            confined: true
         )
     }
 
@@ -296,7 +320,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .line,
-            extending: false
+            extending: false,
+            confined: true
         )
     }
 
@@ -304,7 +329,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .line,
-            extending: true
+            extending: true,
+            confined: true
         )
     }
 
@@ -312,7 +338,8 @@ extension STTextView {
         setTextSelections(
             direction: .right,
             destination: .line,
-            extending: false
+            extending: false,
+            confined: true
         )
     }
 
@@ -320,7 +347,8 @@ extension STTextView {
         setTextSelections(
             direction: .right,
             destination: .line,
-            extending: true
+            extending: true,
+            confined: true
         )
     }
 
@@ -328,7 +356,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .paragraph,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -336,7 +365,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .paragraph,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -344,7 +374,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .paragraph,
-            extending: false
+            extending: false,
+            confined: true
         )
     }
 
@@ -352,7 +383,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .paragraph,
-            extending: true
+            extending: true,
+            confined: true
         )
     }
 
@@ -360,7 +392,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .paragraph,
-            extending: false
+            extending: false,
+            confined: true
         )
     }
 
@@ -368,7 +401,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .paragraph,
-            extending: true
+            extending: true,
+            confined: true
         )
     }
 
@@ -376,7 +410,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .document,
-            extending: false
+            extending: false,
+            confined: false
         )
     }
 
@@ -384,7 +419,8 @@ extension STTextView {
         setTextSelections(
             direction: .backward,
             destination: .document,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
@@ -392,7 +428,8 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .document,
-            extending: false
+            extending: false, 
+            confined: false
         )
     }
 
@@ -400,11 +437,17 @@ extension STTextView {
         setTextSelections(
             direction: .forward,
             destination: .document,
-            extending: true
+            extending: true,
+            confined: false
         )
     }
 
-    private func setTextSelections(direction: NSTextSelectionNavigation.Direction, destination: NSTextSelectionNavigation.Destination, extending: Bool) {
+    private func setTextSelections(
+        direction: NSTextSelectionNavigation.Direction,
+        destination: NSTextSelectionNavigation.Destination,
+        extending: Bool,
+        confined: Bool
+    ) {
         guard isSelectable else { return }
 
         textLayoutManager.textSelections = textLayoutManager.textSelections.compactMap { textSelection in
@@ -413,7 +456,7 @@ extension STTextView {
                 direction: direction,
                 destination: destination,
                 extending: extending,
-                confined: false
+                confined: confined
             )
         }
 

--- a/Tests/STTextViewTests/TextSelectionNavigationTests.swift
+++ b/Tests/STTextViewTests/TextSelectionNavigationTests.swift
@@ -1,0 +1,436 @@
+import XCTest
+import STTextView
+
+final class TextSelectionNavigationTests: XCTestCase {
+    func testMoveLeft() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveLeft(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+        textView.moveLeft(nil)
+        XCTAssertEqual(NSRange(location: 3, length: 0), textView.selectedRange())
+    }
+
+    func testMoveLeftAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveLeftAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 1), textView.selectedRange())
+        textView.moveLeftAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 3, length: 2), textView.selectedRange())
+    }
+
+    func testMoveRight() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.moveRight(nil)
+        XCTAssertEqual(NSRange(location: 2, length: 0), textView.selectedRange())
+        textView.moveRight(nil)
+        XCTAssertEqual(NSRange(location: 3, length: 0), textView.selectedRange())
+    }
+
+    func testMoveRightAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.moveRightAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 1), textView.selectedRange())
+        textView.moveRightAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 2), textView.selectedRange())
+        textView.moveRightAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 3), textView.selectedRange())
+    }
+
+    func testMoveUp() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 9, length: 0))
+
+        textView.moveUp(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 0), textView.selectedRange())
+        textView.moveUp(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 0), textView.selectedRange())
+    }
+
+    func testMoveUpAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 9, length: 0))
+
+        textView.moveUpAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 4), textView.selectedRange())
+    }
+
+    func testMoveDown() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.moveDown(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 0), textView.selectedRange())
+    }
+
+    func testMoveDownAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.moveDownAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 4), textView.selectedRange())
+    }
+
+    func testMoveForward() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.moveForward(nil)
+        XCTAssertEqual(NSRange(location: 2, length: 0), textView.selectedRange())
+        textView.moveForward(nil)
+        XCTAssertEqual(NSRange(location: 3, length: 0), textView.selectedRange())
+        textView.moveForward(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+    }
+
+    func testMoveForwardAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.moveForwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 1), textView.selectedRange())
+        textView.moveForwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 2), textView.selectedRange())
+        textView.moveForwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 3), textView.selectedRange())
+    }
+
+    func testMoveBackward() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveBackward(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+        textView.moveBackward(nil)
+        XCTAssertEqual(NSRange(location: 3, length: 0), textView.selectedRange())
+        textView.moveBackward(nil)
+        XCTAssertEqual(NSRange(location: 2, length: 0), textView.selectedRange())
+    }
+
+    func testMoveBackwardAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+
+        textView.moveBackwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 3, length: 1), textView.selectedRange())
+        textView.moveBackwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 2, length: 2), textView.selectedRange())
+        textView.moveBackwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 1, length: 3), textView.selectedRange())
+    }
+
+    func testMoveWordLeft() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.moveWordLeft(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 0), textView.selectedRange())
+    }
+
+    func testMoveWordLeftAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.moveWordLeftAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 0), textView.selectedRange())
+    }
+
+    func testMoveWordRight() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("Hello world\nSecond Line"))
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.moveWordRight(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 0), textView.selectedRange())
+        textView.moveWordRight(nil)
+        XCTAssertEqual(NSRange(location: 11, length: 0), textView.selectedRange())
+        textView.moveWordRight(nil)
+        XCTAssertEqual(NSRange(location: 18, length: 0), textView.selectedRange())
+    }
+
+    func testMoveWordRightAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("Hello world\nSecond Line"))
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.moveWordRightAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 5), textView.selectedRange())
+        textView.moveWordRightAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 11), textView.selectedRange())
+        textView.moveWordRightAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 18), textView.selectedRange())
+    }
+
+    func testMoveWordForward() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("Hello world\nSecond Line"))
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.moveWordForward(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 0), textView.selectedRange())
+        textView.moveWordForward(nil)
+        XCTAssertEqual(NSRange(location: 11, length: 0), textView.selectedRange())
+        textView.moveWordForward(nil)
+        XCTAssertEqual(NSRange(location: 18, length: 0), textView.selectedRange())
+    }
+
+    func testMoveWordForwardAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("Hello world\nSecond Line"))
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.moveWordForwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 5), textView.selectedRange())
+        textView.moveWordForwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 11), textView.selectedRange())
+        textView.moveWordForwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 18), textView.selectedRange())
+    }
+
+    func testMoveWordBackward() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("Hello world\nSecond Line"))
+        textView.setSelectedRange(NSRange(location: 12, length: 0))
+
+        textView.moveWordBackward(nil)
+        XCTAssertEqual(NSRange(location: 6, length: 0), textView.selectedRange())
+        textView.moveWordBackward(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 0), textView.selectedRange())
+    }
+
+    func testMoveWordBackwardAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("Hello world\nSecond Line"))
+        textView.setSelectedRange(NSRange(location: 12, length: 0))
+
+        textView.moveWordBackwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 6, length: 6), textView.selectedRange())
+        textView.moveWordBackwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 12), textView.selectedRange())
+    }
+
+    func testMoveToBeginningOfLine() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToBeginningOfLine(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+        textView.moveToBeginningOfLine(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+    }
+
+    func testMoveToBeginningOfLineAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToBeginningOfLineAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 1), textView.selectedRange())
+        textView.moveToBeginningOfLineAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 1), textView.selectedRange())
+    }
+
+    func testMoveToLeftEndOfLine() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToLeftEndOfLine(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+        textView.moveToLeftEndOfLine(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+    }
+
+    func testMoveToLeftEndOfLineAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToLeftEndOfLineAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 1), textView.selectedRange())
+        textView.moveToLeftEndOfLineAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 1), textView.selectedRange())
+    }
+
+    func testMoveToEndOfLine() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToEndOfLine(nil)
+        XCTAssertEqual(NSRange(location: 7, length: 0), textView.selectedRange())
+        textView.moveToEndOfLine(nil)
+        XCTAssertEqual(NSRange(location: 7, length: 0), textView.selectedRange())
+    }
+
+    func testMoveToEndOfLineAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToEndOfLineAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 2), textView.selectedRange())
+        textView.moveToEndOfLineAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 2), textView.selectedRange())
+    }
+
+    func testMoveToRightEndOfLine() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToRightEndOfLine(nil)
+        XCTAssertEqual(NSRange(location: 7, length: 0), textView.selectedRange())
+        textView.moveToRightEndOfLine(nil)
+        XCTAssertEqual(NSRange(location: 7, length: 0), textView.selectedRange())
+    }
+
+    func testMoveToRightEndOfLineAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToRightEndOfLineAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 2), textView.selectedRange())
+        textView.moveToRightEndOfLineAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 2), textView.selectedRange())
+    }
+
+    func testMoveParagraphForwardAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveParagraphForwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 2), textView.selectedRange())
+        textView.moveParagraphForwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 5), textView.selectedRange())
+    }
+
+    func testMoveParagraphBackwardAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveParagraphBackwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 1), textView.selectedRange())
+        textView.moveParagraphBackwardAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 5), textView.selectedRange())
+    }
+
+    func testMoveToBeginningOfParagraph() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToBeginningOfParagraph(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+        textView.moveToBeginningOfParagraph(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 0), textView.selectedRange())
+    }
+
+    func testMoveToBeginningOfParagraphAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToBeginningOfParagraphAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 1), textView.selectedRange())
+        textView.moveToBeginningOfParagraphAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 4, length: 1), textView.selectedRange())
+    }
+
+    func testMoveToEndOfParagraph() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToEndOfParagraph(nil)
+        XCTAssertEqual(NSRange(location: 7, length: 0), textView.selectedRange())
+        textView.moveToEndOfParagraph(nil)
+        XCTAssertEqual(NSRange(location: 7, length: 0), textView.selectedRange())
+    }
+
+    func testMoveToEndOfParagraphAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToEndOfParagraphAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 2), textView.selectedRange())
+        textView.moveToEndOfParagraphAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 2), textView.selectedRange())
+    }
+
+    func testMoveToBeginningOfDocument() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToBeginningOfDocument(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 0), textView.selectedRange())
+        textView.moveToBeginningOfDocument(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 0), textView.selectedRange())
+    }
+
+    func testMoveToBeginningOfDocumentAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToBeginningOfDocumentAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 5), textView.selectedRange())
+        textView.moveToBeginningOfDocumentAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 0, length: 5), textView.selectedRange())
+    }
+
+    func testMoveToEndOfDocument() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToEndOfDocument(nil)
+        XCTAssertEqual(NSRange(location: 10, length: 0), textView.selectedRange())
+        textView.moveToEndOfDocument(nil)
+        XCTAssertEqual(NSRange(location: 10, length: 0), textView.selectedRange())
+    }
+
+    func testMoveToEndOfDocumentAndModifySelection() {
+        let textView = STTextView()
+        textView.setAttributedString(.init("012\n456\n89"))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+
+        textView.moveToEndOfDocumentAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 5), textView.selectedRange())
+        textView.moveToEndOfDocumentAndModifySelection(nil)
+        XCTAssertEqual(NSRange(location: 5, length: 5), textView.selectedRange())
+    }
+}
+
+extension NSTextView {
+    func setAttributedString(_ attributedString: NSAttributedString) {
+        textStorage?.setAttributedString(attributedString)
+    }
+}


### PR DESCRIPTION
This PR makes the selection navigation behave like `NSTextView` (and the Editor apps that ship with macOS, e.g. Notes or TextEdit) and adds the corresponding tests [as (partially) discussed](https://github.com/krzyzanowskim/STTextView/discussions/50).

If you add a `typealias STTextView = NSTextView` in the added test file, you can see that `STTextView` now behaves exactly as `NSTextView`. If needed, I can also add another test case that does the same operations on `STTextView` and `NSTextView` and compares that they behave the same.