### PR TITLE
Change undo behaviour

### DIFF
--- a/Sources/STTextView/STTextView+Insert.swift
+++ b/Sources/STTextView/STTextView+Insert.swift
@@ -44,7 +44,9 @@ extension STTextView {
 
     open override func insertNewline(_ sender: Any?) {
         // insert newline with current typing attributes
+        breakUndoCoalescing()
         insertText("\n")
+        breakUndoCoalescing()
     }
 
     open override func insertNewlineIgnoringFieldEditor(_ sender: Any?) {

--- a/Sources/STTextView/STTextView.swift
+++ b/Sources/STTextView/STTextView.swift
@@ -1267,7 +1267,7 @@ import AVFoundation
         delegateProxy.textView(self, didChangeTextIn: textRange, replacementString: replacementString.string)
         didChangeText(in: textRange)
         
-        guard allowsUndo, let undoManager = undoManager, undoManager.isUndoRegistrationEnabled, !undoManager.isRedoing, !undoManager.isUndoing else { return }
+        guard allowsUndo, let undoManager = undoManager, undoManager.isUndoRegistrationEnabled else { return }
 
         // Reach to NSTextStorage because NSTextContentStorage range extraction is cumbersome.
         // A range that is as long as replacement string, so when undo it undo
@@ -1276,8 +1276,8 @@ import AVFoundation
             end: textContentManager.location(textRange.location, offsetBy: replacementString.length)
         ) ?? textRange
 
-       if let coalescingUndoManager = undoManager as? CoalescingUndoManager {
-           if allowsTypingCoalescing && processingKeyEvent {
+        if let coalescingUndoManager = undoManager as? CoalescingUndoManager, !undoManager.isUndoing, !undoManager.isRedoing {
+            if allowsTypingCoalescing && processingKeyEvent {
                coalescingUndoManager.checkCoalescing(range: undoRange)
            } else {
                coalescingUndoManager.endCoalescing()

--- a/Sources/STTextView/Utility/CoalescingUndoManager.swift
+++ b/Sources/STTextView/Utility/CoalescingUndoManager.swift
@@ -25,6 +25,13 @@ final class CoalescingUndoManager: UndoManager {
         super.undo()
     }
 
+    override func redo() {
+        if groupingLevel == 1 {
+            endUndoGrouping()
+        }
+        super.redo()
+    }
+
     func checkCoalescing(range: NSTextRange) {
         defer {
             lastRange = range

--- a/Sources/STTextView/Utility/CoalescingUndoManager.swift
+++ b/Sources/STTextView/Utility/CoalescingUndoManager.swift
@@ -1,108 +1,47 @@
 //  Created by Marcin Krzyzanowski
 //  https://github.com/krzyzanowskim/STTextView/blob/main/LICENSE.md
 
-import Foundation
+import AppKit
+import STTextKitPlus
 
 final class CoalescingUndoManager: UndoManager {
 
-    private(set) var coalescing: (value: TypingTextUndo?, undoAction: ((TypingTextUndo) -> Void)?)?
-
-    private var coalescingIsUndoing: Bool = false
-    private var coalescingIsRedoing: Bool = false
+    private var lastRange: NSTextRange?
 
     var isCoalescing: Bool {
-        coalescing != nil
-    }
-
-    func breakCoalescing() {
-        guard isUndoRegistrationEnabled else {
-            return
-        }
-        
-        // register undo and break coalescing
-        if !isUndoing, !isRedoing, let undoAction = coalescing?.undoAction, let value = coalescing?.value {
-            // Disable implicit grouping to avoid group coalescing and non-coalescing undo
-            groupsByEvent = false
-            beginUndoGrouping()
-            registerUndo(withTarget: self) { _ in
-                undoAction(value)
-            }
-            endUndoGrouping()
-            groupsByEvent = true
-        }
-
-        coalescing = nil
+        lastRange != nil
     }
 
     override init() {
         super.init()
         self.runLoopModes = [.default, .common, .eventTracking, .modalPanel]
-    }
-
-    func coalesce(_ value: TypingTextUndo) {
-        guard isUndoRegistrationEnabled else {
-            return
-        }
-
-        assert(isCoalescing, "Coalescing not started. Call startCoalescing(withTarget:_) first")
-
-        coalescing = (value: value, undoAction: coalescing?.undoAction)
-        return
-    }
-
-    func startCoalescing<Target>(_ value: TypingTextUndo, withTarget target: Target, _ undoAction: @escaping (Target, TypingTextUndo) -> Void) where Target: AnyObject {
-        guard isUndoRegistrationEnabled else { return }
-        coalescing = (value: value, undoAction: { undoAction(target, $0) })
-    }
-
-    override var canRedo: Bool {
-        super.canRedo
-    }
-
-    override var canUndo: Bool {
-        super.canUndo || isCoalescing
-    }
-
-    override var isUndoing: Bool {
-        super.isUndoing || coalescingIsUndoing
-    }
-
-    override var isRedoing: Bool {
-        super.isRedoing || coalescingIsRedoing
+        self.groupsByEvent = false
     }
 
     override func undo() {
-        if let undoAction = coalescing?.undoAction, let value = coalescing?.value {
-            coalescingIsUndoing = true
-            undoAction(value)
-            breakCoalescing()
-            coalescingIsUndoing = false
-            // FIXME: call undo to register redo
-            // When the Undo system performs an undo action,
-            // it expects me to register the redo actions using the same code as for undo.
-            // That makes the coalescing flow tricky to make right right now
-        } else {
-            super.undo()
+        if groupingLevel == 1 {
+            endUndoGrouping()
+        }
+        super.undo()
+    }
+
+    func checkCoalescing(range: NSTextRange) {
+        defer {
+            lastRange = range
+        }
+        guard let lastRange else {
+            beginUndoGrouping()
+            return
+        }
+        if !lastRange.intersects(range) && lastRange.endLocation != range.location {
+            endCoalescing()
+            beginUndoGrouping()
         }
     }
 
-    override func redo() {
-        super.redo()
-    }
-
-    override var undoMenuItemTitle: String {
-        if canUndo {
-            return super.undoMenuItemTitle
-        } else {
-            return NSLocalizedString("Undo", comment: "Undo")
-        }
-    }
-
-    override var redoMenuItemTitle: String {
-        if canRedo {
-            return super.redoMenuItemTitle
-        } else {
-            return NSLocalizedString("Redo", comment: "Redo")
-        }
+    func endCoalescing() {
+        guard groupingLevel > 0 else { return }
+        lastRange = nil
+        endUndoGrouping()
     }
 }

--- a/Sources/STTextView/Utility/TypingTextUndo.swift
+++ b/Sources/STTextView/Utility/TypingTextUndo.swift
@@ -1,9 +1,0 @@
-//  Created by Marcin Krzyzanowski
-//  https://github.com/krzyzanowskim/STTextView/blob/main/LICENSE.md
-
-import AppKit
-
-struct TypingTextUndo {
-    let textRange: NSTextRange
-    let attributedString: NSAttributedString?
-}

--- a/Tests/STTextViewTests/Helpers/NSEvent+Create.swift
+++ b/Tests/STTextViewTests/Helpers/NSEvent+Create.swift
@@ -1,0 +1,238 @@
+#if os(macOS)
+import AppKit
+import Carbon
+
+extension NSEvent {
+    /// Creates an event which can be used in tests.
+    /// It simulates a key down event for the given ASCII character.
+    static func create(
+        characters: String,
+        modifiers: NSEvent.ModifierFlags = [],
+        eventType: NSEvent.EventType = .keyDown
+    ) throws -> NSEvent {
+        guard let keyCode = keyMapping[characters] else { throw SetupError.unknownCharacters(characters) }
+
+        guard let event = NSEvent.keyEvent(
+            with: eventType,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: CFTimeInterval(),
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        ) else { throw SetupError.eventCreationError }
+
+        return event
+    }
+
+    /// Creates an event which can be used in tests.
+    /// It simulates a key down event for the given device-independent key.
+    static func create(
+        key: KeyboardIndependentKeys,
+        modifiers: NSEvent.ModifierFlags = [],
+        eventType: NSEvent.EventType = .keyDown
+    ) throws -> NSEvent {
+        let keyCode = CGKeyCode(UInt16(key.keyCode))
+        guard
+            let cgEvent = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
+            let nsEvent = NSEvent(cgEvent: cgEvent)
+        else { throw SetupError.eventCreationError }
+
+        guard let event = NSEvent.keyEvent(
+            with: eventType,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: CFTimeInterval(),
+            windowNumber: 0,
+            context: nil,
+            characters: nsEvent.characters ?? "",
+            charactersIgnoringModifiers: nsEvent.charactersIgnoringModifiers ?? "",
+            isARepeat: false,
+            keyCode: keyCode
+        ) else { throw SetupError.eventCreationError }
+
+        return event
+    }
+}
+
+/// A mapping where the mapping's key is an ASCII character and the value is the key code for the character based on current keyboard.
+/// This is used to translate keyboard-dependent characters into the correct keyboard.
+private let keyMapping: [String: UInt16] = {
+    var mapping: [String: UInt16] = [:]
+    for keyCode in (0..<128) {
+        guard let cgevent = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(keyCode), keyDown: true) else { continue }
+        guard let nsevent = NSEvent(cgEvent: cgevent) else { continue }
+
+        guard nsevent.type == .keyDown,
+              nsevent.specialKey == nil,
+              let characters = nsevent.charactersIgnoringModifiers,
+              !characters.isEmpty
+        else { continue }
+        mapping[characters] = UInt16(keyCode)
+    }
+
+    return mapping
+}()
+
+/// All keys which are independent from the keyboard, so they have the same key code on all keyboards.
+enum KeyboardIndependentKeys {
+    case `return`
+    case tab
+    case space
+    case delete
+    case escape
+    case command
+    case shift
+    case capsLock
+    case option
+    case control
+    case rightCommand
+    case rightShift
+    case rightOption
+    case rightControl
+    case function
+    case volumeUp
+    case volumeDown
+    case mute
+    case f1
+    case f2
+    case f3
+    case f4
+    case f5
+    case f6
+    case f7
+    case f8
+    case f9
+    case f10
+    case f11
+    case f12
+    case f13
+    case f14
+    case f15
+    case f16
+    case f17
+    case f18
+    case f19
+    case f20
+    case help
+    case home
+    case pageUp
+    case forwardDelete
+    case end
+    case pageDown
+    case leftArrow
+    case rightArrow
+    case downArrow
+    case upArrow
+
+    var keyCode: Int {
+        switch self {
+        case .`return`:
+            return kVK_Return
+        case .tab:
+            return kVK_Tab
+        case .space:
+            return kVK_Space
+        case .delete:
+            return kVK_Delete
+        case .escape:
+            return kVK_Escape
+        case .command:
+            return kVK_Command
+        case .shift:
+            return kVK_Shift
+        case .capsLock:
+            return kVK_CapsLock
+        case .option:
+            return kVK_Option
+        case .control:
+            return kVK_Control
+        case .rightCommand:
+            return kVK_RightCommand
+        case .rightShift:
+            return kVK_RightShift
+        case .rightOption:
+            return kVK_RightOption
+        case .rightControl:
+            return kVK_RightControl
+        case .function:
+            return kVK_Function
+        case .volumeUp:
+            return kVK_VolumeUp
+        case .volumeDown:
+            return kVK_VolumeDown
+        case .mute:
+            return kVK_Mute
+        case .f1:
+            return kVK_F1
+        case .f2:
+            return kVK_F2
+        case .f3:
+            return kVK_F3
+        case .f4:
+            return kVK_F4
+        case .f5:
+            return kVK_F5
+        case .f6:
+            return kVK_F6
+        case .f7:
+            return kVK_F7
+        case .f8:
+            return kVK_F8
+        case .f9:
+            return kVK_F9
+        case .f10:
+            return kVK_F10
+        case .f11:
+            return kVK_F11
+        case .f12:
+            return kVK_F12
+        case .f13:
+            return kVK_F13
+        case .f14:
+            return kVK_F14
+        case .f15:
+            return kVK_F15
+        case .f16:
+            return kVK_F16
+        case .f17:
+            return kVK_F17
+        case .f18:
+            return kVK_F18
+        case .f19:
+            return kVK_F19
+        case .f20:
+            return kVK_F20
+        case .help:
+            return kVK_Help
+        case .home:
+            return kVK_Home
+        case .pageUp:
+            return kVK_PageUp
+        case .forwardDelete:
+            return kVK_ForwardDelete
+        case .end:
+            return kVK_End
+        case .pageDown:
+            return kVK_PageDown
+        case .leftArrow:
+            return kVK_LeftArrow
+        case .rightArrow:
+            return kVK_RightArrow
+        case .downArrow:
+            return kVK_DownArrow
+        case .upArrow:
+            return kVK_UpArrow
+        }
+    }
+}
+
+enum SetupError: Error {
+    case unknownCharacters(String)
+    case eventCreationError
+}
+
+#endif

--- a/Tests/STTextViewTests/UndoTests.swift
+++ b/Tests/STTextViewTests/UndoTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import STTextView
+
+final class UndoTests: XCTestCase {
+    func testInsertingAtEndAndUndo() {
+        let textView = STTextView()
+        textView.insertText("a")
+        textView.insertText("b")
+
+        textView.undo(nil)
+        XCTAssertEqual(textView.string, "a")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 1, length: 0))
+    }
+    
+    func testPasteLongerThanCurrentContentUndo() {
+        let textView = STTextView()
+        textView.string = "first line\nsecond line"
+        textView.setSelectedRange(NSRange(location: 11, length: 11))
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("new second line\nthird line", forType: .string)
+
+        textView.paste(nil)
+        XCTAssertEqual(textView.string, "first line\nnew second line\nthird line")
+
+        textView.undo(nil)
+        XCTAssertEqual(textView.string, "first line\nsecond line")
+        textView.setSelectedRange(NSRange(location: 11, length: 11))
+    }
+    
+    func testInsertBetweenAndUndo() {
+        let textView = STTextView()
+        textView.insertText("123456789")
+        textView.setSelectedRange(NSRange(location: 3, length: 3))
+
+        textView.insertText("a")
+        XCTAssertEqual(textView.string, "123a789")
+
+        textView.undo(nil)
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 3, length: 3))
+        XCTAssertEqual(textView.string, "123456789")
+    }
+
+    func testTypingCoalescing() throws {
+        let textView = STTextView()
+        textView.keyDown(with: try .create(characters: "a"))
+        textView.keyDown(with: try .create(characters: "b"))
+        textView.keyDown(with: try .create(key: .return))
+        textView.keyDown(with: try .create(characters: "c"))
+        textView.keyDown(with: try .create(characters: "d"))
+        XCTAssertEqual(textView.string, "ab\ncd")
+
+        textView.undo(nil)
+        XCTAssertEqual(textView.string, "ab\n")
+
+        textView.undo(nil)
+        XCTAssertEqual(textView.string, "ab")
+
+        textView.undo(nil)
+        XCTAssertEqual(textView.string, "")
+    }
+}

--- a/Tests/STTextViewTests/UndoTests.swift
+++ b/Tests/STTextViewTests/UndoTests.swift
@@ -58,4 +58,25 @@ final class UndoTests: XCTestCase {
         textView.undo(nil)
         XCTAssertEqual(textView.string, "")
     }
+
+    func testRedo() {
+        let textView = STTextView()
+        textView.insertText("123456789")
+        textView.setSelectedRange(NSRange(location: 3, length: 3))
+
+        textView.insertText("a")
+        XCTAssertEqual(textView.string, "123a789")
+
+        textView.undo(nil)
+        XCTAssertEqual(textView.string, "123456789")
+
+        textView.undo(nil)
+        XCTAssertEqual(textView.string, "")
+
+        textView.redo(nil)
+        XCTAssertEqual(textView.string, "123456789")
+
+        textView.redo(nil)
+        XCTAssertEqual(textView.string, "123a789")
+    }
 }


### PR DESCRIPTION
This pull request changes the behaviour of the undo functionality and fixes some small issues in the current implementation: 
* If you edited at the end of the current text (e.g. by typing at the end of the text) and used undo, then the undo didn't work properly and only the cursor moved, but the text was not removed again. This happened because the undo range was calculated before the text was added, therefore the undo range was always too small.
* If you pasted text that was longer than the end of the document and used undo, then the text ended up in a wrong state and parts of the text were repeated.
* An undo operation could happen at the wrong place in the text.

Unlike before, a newline will now break the typing coalescing which is the same behaviour as in other text editors (e.g. Xcode or TextEdit).

Also, an undo operation will now restore the text selection that existed when the operation that is undone was done, again mimicking the behaviour of other editors such as Xcode.

Additionally, this pull request provides some handy helpers to create keyboard events that can be used in tests.