### PR TITLE
Preserves position in line fragments when moving up and down

### DIFF
--- a/Sources/STTextViewUIKit/Extensions/NSTextLayoutManager+Helpers.swift
+++ b/Sources/STTextViewUIKit/Extensions/NSTextLayoutManager+Helpers.swift
@@ -5,106 +5,52 @@ import UIKit
 
 extension NSTextLayoutManager {
 
-    func location(
-        from location: NSTextLocation,
-        in direction: NSTextSelectionNavigation.Direction,
-        offset: Int
-    ) -> NSTextLocation? {
-        guard var naiveTargetLocation = destinationSelection(
-            from: location,
-            in: direction,
-            offset: offset
-        )?.textRanges.first?.location else {
-            return nil
-        }
-        guard direction == .up || direction == .down else {
-            return naiveTargetLocation
-        }
-        // Make sure we keep the selection at the same location in line fragments as we move up and down.
-        if naiveTargetLocation.compare(documentRange.endLocation) == .orderedSame {
-            naiveTargetLocation = self.location(documentRange.endLocation, offsetBy: -1) ?? naiveTargetLocation
-        }
-        guard let (originLine, originLineFragment) = textLayoutFragmentAndTextLineFragment(at: location),
-              let (targetLine, targetLineFragment) = textLayoutFragmentAndTextLineFragment(at: naiveTargetLocation) else {
-            return nil
-        }
-        let locationOffsetInOriginLine = self.offset(from: originLine.rangeInElement.location, to: location)
-        let originPointOnScreen = originLineFragment.locationForCharacter(at: locationOffsetInOriginLine)
-        let targetPointOnScreen = CGPoint(x: originPointOnScreen.x, y: targetLineFragment.typographicBounds.minY)
-        var offsetInTargetLine = targetLineFragment.characterIndex(for: targetPointOnScreen)
-        if offsetInTargetLine == NSNotFound {
-            offsetInTargetLine = targetLineFragment.characterRange.length - 1
-        }
-        guard let targetLocation = self.location(targetLine.rangeInElement.location, offsetBy: offsetInTargetLine) else {
-            return nil
-        }
-        let movementRange = if location.compare(targetLocation) == .orderedAscending {
-            NSTextRange(location: location, end: targetLocation)
-        } else {
-            NSTextRange(location: targetLocation, end: location)
-        }
-        guard let movementRange else {
-            return nil
-        }
-        let lineFragmentsMovedBy = textLineFragments(in: movementRange)
-        guard offset <= lineFragmentsMovedBy.count - 1 else {
-            // If we were unable to move the requested number of line fragments then we move to the bounds of the document. This behavior is expected by UITextInput and ensures it can be navigated correctly using the keyboard.
-            return direction == .up ? documentRange.location : documentRange.endLocation
-        }
-        return targetLocation
-    }
-
-}
-
-private extension NSTextLayoutManager {
-    private func destinationSelection(
-        from sourceLocation: NSTextLocation,
+    func destinationSelection(
+        from originTextSelection: NSTextSelection,
         in direction: NSTextSelectionNavigation.Direction,
         offset: Int
     ) -> NSTextSelection? {
-        let sourceTextSelection = NSTextSelection(sourceLocation, affinity: .downstream)
-        var result: NSTextSelection? = sourceTextSelection
-        for _ in 0 ..< offset {
-            result = textSelectionNavigation.destinationSelection(
-                for: result ?? sourceTextSelection,
-                direction: direction,
-                destination: .character,
-                extending: false,
-                confined: false
-            )
+        guard offset > 0 else {
+            return originTextSelection
         }
-        return result
+        let destinationTextSelection = textSelectionNavigation.destinationSelection(
+            for: originTextSelection,
+            direction: direction,
+            destination: .character,
+            extending: false,
+            confined: false
+        )
+        guard let destinationTextSelection else {
+            return nil
+        }
+        return destinationSelection(
+            from: destinationTextSelection,
+            in: direction,
+            offset: offset - 1
+        )
     }
 
-    private func textLayoutFragment(at textLocation: NSTextLocation) -> NSTextLayoutFragment? {
-        var result: NSTextLayoutFragment?
-        enumerateTextLayoutFragments(from: textLocation) { textLayoutFragment in
-            result = textLayoutFragment
-            return false
-        }
-        return result
-    }
-
-    private func textLayoutFragmentAndTextLineFragment(
+    func textLayoutFragmentAndTextLineFragment(
         at textLocation: NSTextLocation
     ) -> (NSTextLayoutFragment, NSTextLineFragment)? {
         guard let textLayoutFragment = textLayoutFragment(at: textLocation) else {
             return nil
         }
         let offset = offset(from: textLayoutFragment.rangeInElement.location, to: textLocation)
-        guard let textLineFragment = textLayoutFragment.textLineFragments.first(
-            where: { $0.characterRange.contains(offset) }
-        ) else {
+        let textLineFragments = textLayoutFragment.textLineFragments
+        guard let textLineFragment = textLineFragments.first(where: { $0.characterRange.contains(offset) }) else {
             return nil
         }
         return (textLayoutFragment, textLineFragment)
     }
+}
 
-    private func textLineFragments(in textRange: NSTextRange) -> [NSTextLineFragment] {
-        var result: [NSTextLineFragment] = []
-        enumerateTextLayoutFragments(from: textRange.location) { textLayoutFragment in
-            result += textLayoutFragment.textLineFragments
-            return textLayoutFragment.rangeInElement.endLocation.compare(textRange.endLocation) != .orderedDescending
+private extension NSTextLayoutManager {
+    private func textLayoutFragment(at textLocation: NSTextLocation) -> NSTextLayoutFragment? {
+        var result: NSTextLayoutFragment?
+        enumerateTextLayoutFragments(from: textLocation) { textLayoutFragment in
+            result = textLayoutFragment
+            return false
         }
         return result
     }

--- a/Sources/STTextViewUIKit/Extensions/NSTextLayoutManager+Helpers.swift
+++ b/Sources/STTextViewUIKit/Extensions/NSTextLayoutManager+Helpers.swift
@@ -13,18 +13,18 @@ extension NSTextLayoutManager {
         guard offset > 0 else {
             return originTextSelection
         }
-        let destinationTextSelection = textSelectionNavigation.destinationSelection(
+        let result = textSelectionNavigation.destinationSelection(
             for: originTextSelection,
             direction: direction,
             destination: .character,
             extending: false,
             confined: false
         )
-        guard let destinationTextSelection else {
+        guard let result else {
             return nil
         }
         return destinationSelection(
-            from: destinationTextSelection,
+            from: result,
             in: direction,
             offset: offset - 1
         )

--- a/Sources/STTextViewUIKit/Extensions/NSTextLayoutManager+Helpers.swift
+++ b/Sources/STTextViewUIKit/Extensions/NSTextLayoutManager+Helpers.swift
@@ -1,0 +1,111 @@
+//  Created by Marcin Krzyzanowski
+//  https://github.com/krzyzanowskim/STTextView/blob/main/LICENSE.md
+
+import UIKit
+
+extension NSTextLayoutManager {
+
+    func location(
+        from location: NSTextLocation,
+        in direction: NSTextSelectionNavigation.Direction,
+        offset: Int
+    ) -> NSTextLocation? {
+        guard var naiveTargetLocation = destinationSelection(
+            from: location,
+            in: direction,
+            offset: offset
+        )?.textRanges.first?.location else {
+            return nil
+        }
+        guard direction == .up || direction == .down else {
+            return naiveTargetLocation
+        }
+        // Make sure we keep the selection at the same location in line fragments as we move up and down.
+        if naiveTargetLocation.compare(documentRange.endLocation) == .orderedSame {
+            naiveTargetLocation = self.location(documentRange.endLocation, offsetBy: -1) ?? naiveTargetLocation
+        }
+        guard let (originLine, originLineFragment) = textLayoutFragmentAndTextLineFragment(at: location),
+              let (targetLine, targetLineFragment) = textLayoutFragmentAndTextLineFragment(at: naiveTargetLocation) else {
+            return nil
+        }
+        let locationOffsetInOriginLine = self.offset(from: originLine.rangeInElement.location, to: location)
+        let originPointOnScreen = originLineFragment.locationForCharacter(at: locationOffsetInOriginLine)
+        let targetPointOnScreen = CGPoint(x: originPointOnScreen.x, y: targetLineFragment.typographicBounds.minY)
+        var offsetInTargetLine = targetLineFragment.characterIndex(for: targetPointOnScreen)
+        if offsetInTargetLine == NSNotFound {
+            offsetInTargetLine = targetLineFragment.characterRange.length - 1
+        }
+        guard let targetLocation = self.location(targetLine.rangeInElement.location, offsetBy: offsetInTargetLine) else {
+            return nil
+        }
+        let movementRange = if location.compare(targetLocation) == .orderedAscending {
+            NSTextRange(location: location, end: targetLocation)
+        } else {
+            NSTextRange(location: targetLocation, end: location)
+        }
+        guard let movementRange else {
+            return nil
+        }
+        let lineFragmentsMovedBy = textLineFragments(in: movementRange)
+        guard offset <= lineFragmentsMovedBy.count - 1 else {
+            // If we were unable to move the requested number of line fragments then we move to the bounds of the document. This behavior is expected by UITextInput and ensures it can be navigated correctly using the keyboard.
+            return direction == .up ? documentRange.location : documentRange.endLocation
+        }
+        return targetLocation
+    }
+
+}
+
+private extension NSTextLayoutManager {
+    private func destinationSelection(
+        from sourceLocation: NSTextLocation,
+        in direction: NSTextSelectionNavigation.Direction,
+        offset: Int
+    ) -> NSTextSelection? {
+        let sourceTextSelection = NSTextSelection(sourceLocation, affinity: .downstream)
+        var result: NSTextSelection? = sourceTextSelection
+        for _ in 0 ..< offset {
+            result = textSelectionNavigation.destinationSelection(
+                for: result ?? sourceTextSelection,
+                direction: direction,
+                destination: .character,
+                extending: false,
+                confined: false
+            )
+        }
+        return result
+    }
+
+    private func textLayoutFragment(at textLocation: NSTextLocation) -> NSTextLayoutFragment? {
+        var result: NSTextLayoutFragment?
+        enumerateTextLayoutFragments(from: textLocation) { textLayoutFragment in
+            result = textLayoutFragment
+            return false
+        }
+        return result
+    }
+
+    private func textLayoutFragmentAndTextLineFragment(
+        at textLocation: NSTextLocation
+    ) -> (NSTextLayoutFragment, NSTextLineFragment)? {
+        guard let textLayoutFragment = textLayoutFragment(at: textLocation) else {
+            return nil
+        }
+        let offset = offset(from: textLayoutFragment.rangeInElement.location, to: textLocation)
+        guard let textLineFragment = textLayoutFragment.textLineFragments.first(
+            where: { $0.characterRange.contains(offset) }
+        ) else {
+            return nil
+        }
+        return (textLayoutFragment, textLineFragment)
+    }
+
+    private func textLineFragments(in textRange: NSTextRange) -> [NSTextLineFragment] {
+        var result: [NSTextLineFragment] = []
+        enumerateTextLayoutFragments(from: textRange.location) { textLayoutFragment in
+            result += textLayoutFragment.textLineFragments
+            return textLayoutFragment.rangeInElement.endLocation.compare(textRange.endLocation) != .orderedDescending
+        }
+        return result
+    }
+}

--- a/Sources/STTextViewUIKit/Extensions/NSTextLayoutManager+Helpers.swift
+++ b/Sources/STTextViewUIKit/Extensions/NSTextLayoutManager+Helpers.swift
@@ -30,28 +30,4 @@ extension NSTextLayoutManager {
         )
     }
 
-    func textLayoutFragmentAndTextLineFragment(
-        at textLocation: NSTextLocation
-    ) -> (NSTextLayoutFragment, NSTextLineFragment)? {
-        guard let textLayoutFragment = textLayoutFragment(at: textLocation) else {
-            return nil
-        }
-        let offset = offset(from: textLayoutFragment.rangeInElement.location, to: textLocation)
-        let textLineFragments = textLayoutFragment.textLineFragments
-        guard let textLineFragment = textLineFragments.first(where: { $0.characterRange.contains(offset) }) else {
-            return nil
-        }
-        return (textLayoutFragment, textLineFragment)
-    }
-}
-
-private extension NSTextLayoutManager {
-    private func textLayoutFragment(at textLocation: NSTextLocation) -> NSTextLayoutFragment? {
-        var result: NSTextLayoutFragment?
-        enumerateTextLayoutFragments(from: textLocation) { textLayoutFragment in
-            result = textLayoutFragment
-            return false
-        }
-        return result
-    }
 }

--- a/Sources/STTextViewUIKit/STTextView+UITextInput.swift
+++ b/Sources/STTextViewUIKit/STTextView+UITextInput.swift
@@ -121,7 +121,7 @@ extension STTextView: UITextInput {
         guard let textLayoutFragment = textLayoutManager.textLayoutFragment(for: position.location) else {
             return nil
         }
-        guard let textLineFragment = textLayoutManager.textLineFragment(at: position.location) else {
+        guard let textLineFragment = textLayoutFragment.textLineFragment(at: position.location) else {
             return nil
         }
         let characterOffset = textLayoutManager.offset(from: textLayoutFragment.rangeInElement.location, to: position.location)

--- a/Sources/STTextViewUIKit/STTextView+UITextInput.swift
+++ b/Sources/STTextViewUIKit/STTextView+UITextInput.swift
@@ -118,20 +118,9 @@ extension STTextView: UITextInput {
         guard let position = position as? STTextLocation else {
             return nil
         }
-
-        let positionSelection = NSTextSelection(position.location, affinity: .downstream)
-        var destination: NSTextSelection? = positionSelection
-        for _ in 0..<offset {
-            destination = textLayoutManager.textSelectionNavigation.destinationSelection(
-                for: destination ?? positionSelection,
-                direction: direction.textSelectionNavigationDirection,
-                destination: .character,
-                extending: false,
-                confined: false
-            )
-        }
-
-        return destination?.textRanges.first?.location.uiTextPosition
+        let location = position.location
+        let direction = direction.textSelectionNavigationDirection
+        return textLayoutManager.location(from: location, in: direction, offset: offset)?.uiTextPosition
     }
     
     /* Simple evaluation of positions */

--- a/Sources/STTextViewUIKit/STTextView+UITextInput.swift
+++ b/Sources/STTextViewUIKit/STTextView+UITextInput.swift
@@ -118,9 +118,22 @@ extension STTextView: UITextInput {
         guard let position = position as? STTextLocation else {
             return nil
         }
-        let location = position.location
-        let direction = direction.textSelectionNavigationDirection
-        return textLayoutManager.location(from: location, in: direction, offset: offset)?.uiTextPosition
+        guard let textLayoutFragment = textLayoutManager.textLayoutFragment(for: position.location) else {
+            return nil
+        }
+        guard let textLineFragment = textLayoutManager.textLineFragment(at: position.location) else {
+            return nil
+        }
+        let characterOffset = textLayoutManager.offset(from: textLayoutFragment.rangeInElement.location, to: position.location)
+        let characterLocation = textLineFragment.locationForCharacter(at: characterOffset)
+        let originTextSelection = NSTextSelection(position.location, affinity: .upstream)
+        originTextSelection.anchorPositionOffset = characterLocation.x
+        let destinationTextSelection = textLayoutManager.destinationSelection(
+            from: originTextSelection,
+            in: direction.textSelectionNavigationDirection,
+            offset: offset
+        )
+        return destinationTextSelection?.textRanges.first?.location.uiTextPosition
     }
     
     /* Simple evaluation of positions */


### PR DESCRIPTION
Ensures the location is preserved when navigating up and down between line fragments using the keyboard. The behavior matches UITextView. The videos below compares the behavior before and after these changes.

The implementation uses [anchorPositionOffset](https://developer.apple.com/documentation/uikit/nstextselection/3801817-anchorpositionoffset?changes=la_3) on NSTextSelection. TextKit 2 automatically populates this on macOS but we need to do it manually on iOS to achieve the same behavior.

**Before**

https://github.com/user-attachments/assets/10345ad7-b657-47cb-aefa-09ae19dcb506

**After**

https://github.com/user-attachments/assets/180d8cb6-937b-466a-b2c1-4491e9741d9b
