### PR TITLE
Prevent title bar clipping content when using .fullSizeContentView windows

### DIFF
--- a/Sources/STTextViewAppKit/STTextView+Gutter.swift
+++ b/Sources/STTextViewAppKit/STTextView+Gutter.swift
@@ -42,8 +42,14 @@ extension STTextView {
 
     internal func layoutGutter() {
         if let gutterView {
-            gutterView.frame.origin = frame.origin
-            gutterView.frame.size.height = contentView.visibleRect.height
+            var origin = frame.origin
+            var height = contentView.visibleRect.height
+            if let scrollView {
+                origin.y = scrollView.contentInsets.top
+                height = scrollView.documentVisibleRect.height - scrollView.contentInsets.top
+            }
+            gutterView.frame.origin = origin
+            gutterView.frame.size.height = height
             layoutGutterLineNumbers()
             layoutGutterMarkers()
         }
@@ -101,7 +107,7 @@ extension STTextView {
                 numberCell.frame = CGRect(
                     origin: CGPoint(
                         x: bounds.minX,
-                        y: selectionFrame.origin.y - scrollView.contentView.bounds.minY
+                        y: selectionFrame.origin.y - scrollView.contentView.bounds.minY - scrollView.contentInsets.top
                     ),
                     size: CGSize(
                         width: gutterView.containerView.frame.width,
@@ -169,7 +175,7 @@ extension STTextView {
                             lineFragmentFrame = CGRect(
                                 origin: CGPoint(
                                     x: layoutFragment.layoutFragmentFrame.origin.x + textLineFragment.typographicBounds.origin.x,
-                                    y: layoutFragment.layoutFragmentFrame.origin.y + textLineFragment.typographicBounds.origin.y - scrollView.contentView.bounds.minY/*contentOffset.y*/
+                                    y: layoutFragment.layoutFragmentFrame.origin.y + textLineFragment.typographicBounds.origin.y - scrollView.contentView.bounds.minY - scrollView.contentInsets.top
                                 ),
                                 size: CGSize(
                                     width: textLineFragment.typographicBounds.width,
@@ -189,7 +195,7 @@ extension STTextView {
                             lineFragmentFrame = CGRect(
                                 origin: CGPoint(
                                     x: layoutFragment.layoutFragmentFrame.origin.x + prevTextLineFragment.typographicBounds.origin.x,
-                                    y: layoutFragment.layoutFragmentFrame.origin.y + prevTextLineFragment.typographicBounds.maxY - scrollView.contentView.bounds.minY/*contentOffset.y*/
+                                    y: layoutFragment.layoutFragmentFrame.origin.y + prevTextLineFragment.typographicBounds.maxY - scrollView.contentView.bounds.minY - scrollView.contentInsets.top
                                 ),
                                 size: CGSize(
                                     width: textLineFragment.typographicBounds.width,
@@ -207,7 +213,7 @@ extension STTextView {
                         lineFragmentFrame = CGRect(
                             origin: CGPoint(
                                 x: layoutFragment.layoutFragmentFrame.origin.x + textLineFragment.typographicBounds.origin.x,
-                                y: layoutFragment.layoutFragmentFrame.origin.y + textLineFragment.typographicBounds.origin.y - scrollView.contentView.bounds.minY/*contentOffset.y*/
+                                y: layoutFragment.layoutFragmentFrame.origin.y + textLineFragment.typographicBounds.origin.y - scrollView.contentView.bounds.minY - scrollView.contentInsets.top
                             ),
                             size: CGSize(
                                 width: layoutFragment.layoutFragmentFrame.width, // extend width to he fragment layout for the convenience of gutter

--- a/Sources/STTextViewAppKit/STTextView+Gutter.swift
+++ b/Sources/STTextViewAppKit/STTextView+Gutter.swift
@@ -45,7 +45,7 @@ extension STTextView {
             var origin = frame.origin
             var height = contentView.visibleRect.height
             if let scrollView {
-                origin.y = scrollView.contentInsets.top
+                origin.y = origin.y + scrollView.contentInsets.top
                 height = scrollView.documentVisibleRect.height - scrollView.contentInsets.top
             }
             gutterView.frame.origin = origin

--- a/Sources/STTextViewAppKit/STTextView.swift
+++ b/Sources/STTextViewAppKit/STTextView.swift
@@ -1182,18 +1182,19 @@ import AVFoundation
         logger.debug("usageBoundsForTextContainer \(usageBoundsForTextContainer.debugDescription) \(#function)")
 
         let gutterWidth = gutterView?.frame.width ?? 0
+        let topScrollInset = scrollView?.contentInsets.top ?? 0
         let frameSize: CGSize
         if isHorizontallyResizable {
             // no-wrapping
             frameSize = CGSize(
                 width: max(usageBoundsForTextContainer.size.width + gutterWidth, visibleRect.width),
-                height: max(usageBoundsForTextContainer.size.height, visibleRect.height)
+                height: max(usageBoundsForTextContainer.size.height, visibleRect.height - topScrollInset)
             )
         } else {
             // wrapping
             frameSize = CGSize(
                 width: visibleRect.width,
-                height: max(usageBoundsForTextContainer.size.height, visibleRect.height)
+                height: max(usageBoundsForTextContainer.size.height, visibleRect.height - topScrollInset)
             )
         }
 

--- a/Sources/STTextViewAppKit/STTextView.swift
+++ b/Sources/STTextViewAppKit/STTextView.swift
@@ -1182,19 +1182,19 @@ import AVFoundation
         logger.debug("usageBoundsForTextContainer \(usageBoundsForTextContainer.debugDescription) \(#function)")
 
         let gutterWidth = gutterView?.frame.width ?? 0
-        let topScrollInset = scrollView?.contentInsets.top ?? 0
+        let verticalScrollInset = scrollView?.contentInsets.verticalInsets ?? 0
         let frameSize: CGSize
         if isHorizontallyResizable {
             // no-wrapping
             frameSize = CGSize(
                 width: max(usageBoundsForTextContainer.size.width + gutterWidth, visibleRect.width),
-                height: max(usageBoundsForTextContainer.size.height, visibleRect.height - topScrollInset)
+                height: max(usageBoundsForTextContainer.size.height, visibleRect.height - verticalScrollInset)
             )
         } else {
             // wrapping
             frameSize = CGSize(
                 width: visibleRect.width,
-                height: max(usageBoundsForTextContainer.size.height, visibleRect.height - topScrollInset)
+                height: max(usageBoundsForTextContainer.size.height, visibleRect.height - verticalScrollInset)
             )
         }
 


### PR DESCRIPTION
When a scrollable text view is placed at the top of a window using .fullSizeContentView, content will appear under the title bar.

This PR uses the scroll view contentInsets to shunt content down into the normally visible area.

I'm not familiar enough with the codebase to be 100% sure I've got all the places that could be affected by this, but for my use it seems to be OK.

Hope it's OK to drop drive-by PRs like this, would normally open an issue first but they're turned off :).