### PR TITLE
Accept dragged text from within and outside the text view

### DIFF
--- a/Sources/STTextViewAppKit/STTextView+NSDraggingDestination.swift
+++ b/Sources/STTextViewAppKit/STTextView+NSDraggingDestination.swift
@@ -15,7 +15,7 @@ extension STTextView {
     }
     
     open override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        return .copy
+        return sender.draggingSource == nil ? .copy : .move
     }
     
     open override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
@@ -28,10 +28,15 @@ extension STTextView {
             isDragging: false,
             visual: false
         )
-        return .copy
+        return sender.draggingSource == nil ? .copy : .move
     }
     
     open override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        if let originalDragSelections {
+            performInternalDragOperation(textSelections: originalDragSelections)
+            return true
+        }
+        
         let pasteboard = sender.draggingPasteboard
         if isRichText && pasteboard.canReadItem(withDataConformingToTypes: [UTType.rtf.identifier]) {
             return readSelection(from: sender.draggingPasteboard, type: .rtf)
@@ -40,4 +45,36 @@ extension STTextView {
         }
         return false
     }
+    
+    // Takes an array of selections, removes them from the text and inserts them at a new point
+    private func performInternalDragOperation(textSelections: [NSTextRange]) {
+        guard let insertionPoint = textLayoutManager.textSelections.flatMap(\.textRanges).first else { return }
+        
+        let sortedSelections = textSelections.sorted {
+            NSRange($0, in: textContentManager).location > NSRange($1, in: textContentManager).location
+        }
+        
+        let textToInsert = sortedSelections
+            .compactMap { textLayoutManager.textAttributedString(in: $0) }
+            .enumerated()
+            .reduce(NSMutableAttributedString()) { result, item in
+                if item.offset > 0 { result.append(NSAttributedString(string: "\n")) }
+                result.append(item.element)
+                return result
+            }
+        
+        let insertionOffset = NSRange(insertionPoint.location, in: textContentManager).location
+        let deletedBeforeInsertion = sortedSelections
+            .map { NSRange($0, in: textContentManager) }
+            .filter { $0.upperBound <= insertionOffset }
+            .reduce(0) { $0 + $1.length }
+        
+        undoManager?.beginUndoGrouping()
+        for selection in sortedSelections {
+            replaceCharacters(in: NSRange(selection, in: textContentManager), with: "")
+        }
+        insertText(textToInsert, replacementRange: NSRange(location: insertionOffset - deletedBeforeInsertion, length: 0))
+        undoManager?.endUndoGrouping()
+    }
+    
 }

--- a/Sources/STTextViewAppKit/STTextView+NSDraggingDestination.swift
+++ b/Sources/STTextViewAppKit/STTextView+NSDraggingDestination.swift
@@ -2,6 +2,7 @@
 //  https://github.com/krzyzanowskim/STTextView/blob/main/LICENSE.md
 
 import AppKit
+import UniformTypeIdentifiers
 
 /// A set of methods that the destination object (or recipient) of a dragged image must implement.
 ///
@@ -12,5 +13,31 @@ extension STTextView {
         super.concludeDragOperation(sender)
         cleanUpAfterDragOperation()
     }
-
+    
+    open override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        return .copy
+    }
+    
+    open override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        let eventPoint = contentView.convert(sender.draggingLocation, from: nil)
+        updateTextSelection(
+            interactingAt: eventPoint,
+            inContainerAt: textLayoutManager.documentRange.location,
+            anchors: [],
+            extending: false,
+            isDragging: false,
+            visual: false
+        )
+        return .copy
+    }
+    
+    open override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        let pasteboard = sender.draggingPasteboard
+        if isRichText && pasteboard.canReadItem(withDataConformingToTypes: [UTType.rtf.identifier]) {
+            return readSelection(from: sender.draggingPasteboard, type: .rtf)
+        } else if pasteboard.canReadItem(withDataConformingToTypes: [UTType.plainText.identifier]) {
+            return readSelection(from: sender.draggingPasteboard, type: .string)
+        }
+        return false
+    }
 }

--- a/Sources/STTextViewAppKit/STTextView+NSDraggingDestination.swift
+++ b/Sources/STTextViewAppKit/STTextView+NSDraggingDestination.swift
@@ -73,7 +73,9 @@ extension STTextView {
         for selection in sortedSelections {
             replaceCharacters(in: NSRange(selection, in: textContentManager), with: "")
         }
-        insertText(textToInsert, replacementRange: NSRange(location: insertionOffset - deletedBeforeInsertion, length: 0))
+        let insertLocation = insertionOffset - deletedBeforeInsertion
+        insertText(textToInsert, replacementRange: NSRange(location: insertLocation, length: 0))
+        setSelectedRange(NSRange(location: insertLocation + textToInsert.length, length: 0))
         undoManager?.endUndoGrouping()
     }
     

--- a/Sources/STTextViewAppKit/STTextView+NSDraggingSource.swift
+++ b/Sources/STTextViewAppKit/STTextView+NSDraggingSource.swift
@@ -5,6 +5,9 @@ import AppKit
 
 extension STTextView: NSDraggingSource {
 
+    public func draggingSession(_ session: NSDraggingSession, willBeginAt screenPoint: NSPoint) {
+        originalDragSelections = textLayoutManager.textSelections.flatMap(\.textRanges)
+    }
     public func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
         context == .outsideApplication ? .copy : .move
     }

--- a/Sources/STTextViewAppKit/STTextView.swift
+++ b/Sources/STTextViewAppKit/STTextView.swift
@@ -684,6 +684,7 @@ import AVFoundation
 
         setupTextLayoutManager(textLayoutManager)
         setSelectedTextRange(NSTextRange(location: textLayoutManager.documentRange.location), updateLayout: false)
+        registerForDraggedTypes(readablePasteboardTypes)
     }
 
     @available(*, unavailable)

--- a/Sources/STTextViewAppKit/STTextView.swift
+++ b/Sources/STTextViewAppKit/STTextView.swift
@@ -613,6 +613,7 @@ import AVFoundation
     /// keep the anchors unchanged while dragging.
     internal var mouseDraggingSelectionAnchors: [NSTextSelection]? = nil
     internal var draggingSession: NSDraggingSession? = nil
+    internal var originalDragSelections: [NSTextRange]? = nil
 
     open override class var defaultMenu: NSMenu? {
         // evaluated once, and cached
@@ -1482,7 +1483,7 @@ import AVFoundation
     ///
     /// Subclasses may override this method to clean up any additional data structures used for dragging. In your overridden method, be sure to invoke super’s implementation of this method.
     open func cleanUpAfterDragOperation() {
-
+        originalDragSelections = nil
     }
 
     open func addPlugin(_ instance: any STPlugin) {


### PR DESCRIPTION
This implements accepting dragged text from within the text view and from other apps.
It follows from discussion #87.

Dragging in from other apps is quite straightforward, it uses the existing `updateTextSelection` and `readSelection` functions to show the drop location and insert any text.

Dragging within the view is more manual as we've got to gather the text, figure out how the insertion point changes after removing that text, then perform the removal and insertion.

It should be able to cope with dragging from multiple selections, but the view doesn't seem to start a dragging session when there are multiple separate selections. I'm not sure where to change that, but don't think it's required to allow this change as a starting point.

I'm not very familiar with the TextKit 2 APIs, so my implementation of `performInternalDragOperation` could probably be improved a fair bit. Mostly around the conversions between `NSTextRange` and `NSRange`. I'd welcome any suggestions for improvement.