### PR TITLE
Fix state modification during view update in textViewDidChangeSelection

### DIFF
--- a/Sources/STTextViewSwiftUIAppKit/TextView.swift
+++ b/Sources/STTextViewSwiftUIAppKit/TextView.swift
@@ -221,7 +221,10 @@ private struct TextViewRepresentable: NSViewRepresentable {
                 return
             }
 
-            selection = textView.selectedRange()
+            let newSelection = textView.selectedRange()
+            DispatchQueue.main.async { [weak self] in
+                self?.selection = newSelection
+            }
         }
 
     }


### PR DESCRIPTION
## Summary

- Fixes runtime warning: `Modifying state during view update, this will cause undefined behavior` at `TextView.swift:224`
- `textViewDidChangeSelection` was setting the `selection` binding synchronously during a view update cycle
- The fix defers the binding update to the next run loop iteration via `DispatchQueue.main.async`

## Details

When SwiftUI triggers a view update that causes `STTextView` to update its selection, the `NSTextViewDelegate` callback `textViewDidChangeSelection` fires synchronously. Writing back to the `selection` binding (SwiftUI state) inside this callback violates SwiftUI's rule against modifying state during a view update.

The fix captures the new selection value immediately (so it's always current) but defers the actual state mutation to the next main queue tick, breaking the synchronous cycle.

## Test plan

- Verified the runtime warning no longer appears when using `TextView` with a `selection` binding
- Confirmed selection tracking still works correctly after the change
